### PR TITLE
TDT-2361 Bug: changed :booking_id to :booking_ref, as per recent component updates

### DIFF
--- a/scheduler-editor.html
+++ b/scheduler-editor.html
@@ -48,8 +48,8 @@
           requires_session_auth: false, // creates public configuration which does not require session tokens
           scheduler: {
             // callback URLs to be set in email confirmation messages
-            rescheduling_url: `${window.location.origin}/reschedule/:booking_id`,
-            cancellation_url: `${window.location.origin}/cancel/:booking_id`,
+            rescheduling_url: `${window.location.origin}/reschedule/:booking_ref`,
+            cancellation_url: `${window.location.origin}/cancel/:booking_ref`,
           },
         },
       };


### PR DESCRIPTION

# Code changes
- Updated ":booking_id" to ":booking_ref" to align with recent component changes. As it is now, the quickstart fails to create a scheduler config.

# Readiness checklist
- [ ] 

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.